### PR TITLE
Dev20py3

### DIFF
--- a/reconstruction.py
+++ b/reconstruction.py
@@ -282,7 +282,8 @@ if __name__ == '__main__':
     if options.justPedestal:
         ana = analysis(options)
         print("Pedestals done. Exiting.")
-        sw.swift_rm_root_file(options.tmpname)
+        if options.donotremove == False:
+            sw.swift_rm_root_file(options.tmpname)
         sys.exit(0)     
     
     ana = analysis(options)

--- a/supercluster.py
+++ b/supercluster.py
@@ -37,7 +37,7 @@ class SuperClusterAlgorithm:
         return _store
 
     def supercluster(self,clustered_data):
-        gimage = inverse_gaussian_gradient(clustered_data,alpha=500,sigma=2)
+        gimage = inverse_gaussian_gradient(clustered_data)
         # Initial level set
         # this makes alternate squares active at the first iteration of 10 macro-pixels
         #init_ls = checkerboard_level_set(clustered_data.shape, 10)
@@ -46,8 +46,8 @@ class SuperClusterAlgorithm:
         # List with intermediate results for plotting the evolution
         evolution = []
         callback = self.store_evolution_in(evolution)
-        ls = morphological_geodesic_active_contour(gimage, 500, init_ls,
-                                                   smoothing=1, balloon=-3,
+        ls = morphological_geodesic_active_contour(gimage, 300, init_ls,
+                                                   smoothing=1, balloon=-1,
                                                    threshold=0.69,
                                                    iter_callback=callback)
         return ls


### PR DESCRIPTION
Revert the supercluster parameters so to have a similar containment of the clusters in clear cases. 
This in Fe55 makes superclusters which are like:

![image](https://user-images.githubusercontent.com/4517974/78887612-782ebf00-7a60-11ea-9307-e7fb7d0c4555.png)

This restore the parameters of 8f532b6fa123da6cfb765db0f5124d0ff4bae0a3

@gdimperi @fabriziopetrucci this should be tested on simulation to see if the containment is back to reasonable values wrt the true energy
