### PR TITLE
Refinement of the energy calibration for saturation

### DIFF
--- a/modules_config/energyCalibrator.txt
+++ b/modules_config/energyCalibrator.txt
@@ -1,7 +1,12 @@
 {
-'p0'            : 5979,
-'p1'            : 2.051e+4,
-'photonsPerEv'  : 0.5,
-'sliceRadius'   : 15,
+# see: https://docs.google.com/presentation/d/1bn12W-C3hIEkKyB_TVW5HqTTKYBDwcwDK3CCyYn81uo/edit#slide=id.g74e410c918_0_25
+'p3'            : 0.132,
+'p4'            : 1.22,
+'p0'            : 130283.,
+'p2'            : 0.56757,
+'p1'            : 117038.,
+'norm'          : 1.2,
+'xscale'        : 1.5,
+'sliceRadius'   : 30.,
 'noiseThr'      : 2.25,
 }

--- a/plotter/functions.cc
+++ b/plotter/functions.cc
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <TROOT.h>
+#include <TMath.h>
+
+float saturationFactorNLO(float density) {
+  // this gives the energy in eV/ph
+  float ret = 0;
+  if (density<=0) // protection for the formula below
+    ret = 0.85; // seems to provide some continuity
+  else {
+    float x = density/1.5;
+    ret = (0.11 + 1.22*x)/(130283. * (1-TMath::Exp(-1*(TMath::Power(x,0.56757)/117038.))))/1.2;
+  }
+  // std::cout << "saturation factor = " << ret << std::endl;
+  return ret;
+}
+
+float calibratedEnergy(float integral, float density) {
+  // giving the energy in keV
+  return saturationFactorNLO(density) * integral / 1000.; 
+}

--- a/plotter/simple_plot.py
+++ b/plotter/simple_plot.py
@@ -4,6 +4,9 @@ from array import array
 ROOT.gStyle.SetOptStat(111111)
 ROOT.gROOT.SetBatch(True)
 
+if "/functions_cc.so" not in ROOT.gSystem.GetLibraries(): 
+    ROOT.gROOT.ProcessLine(".L functions.cc+")
+
 fe_integral_rescale = 0.1
 cosm_rate_calib = [0.75,0.02] # central value, stat error
 
@@ -918,6 +921,11 @@ def plotHistFit(plotdir,var='integral',i=0):
         var1 = 'sc_integral/sc_nhits'
         leg = 'Density [photons/pix]'
         histlimit = 15
+    elif var == 'energy':
+        var1 = 'calibratedEnergy(sc_integral,sc_integral/sc_nhits)'
+        print ("var1  = ",var1)
+        leg = 'calibrated energy (keV)'
+        histlimit = 20
     else:
         exit()
     

--- a/plotter/simple_plot.py
+++ b/plotter/simple_plot.py
@@ -10,6 +10,14 @@ cosm_rate_calib = [0.75,0.02] # central value, stat error
 def saturationFactor(density):
     return 1.5/1.8 * math.pow(5979 * math.log(20512./(20512.-density)),1.8)/(0.27*density-0.1)
 
+def saturationFactorNLO(density):
+    if density<=0: # protection for the formula below
+        ret = 0.85 # seems to provide some continuity
+    else:
+        x = density/1.5
+        ret = (0.11 + 1.22*x)/(130283. * (1-math.exp(-1*(math.pow(x,0.56757)/117038.))))/1.2
+    return ret
+
 def is60keVBkg(length,density):
     # rough linear decrease density vs length
     central = 14. - length/50.
@@ -212,6 +220,7 @@ def fillSpectra(cluster='sc'):
     ## PMT variables
     ret[('ambe','pmt_integral')]  = ROOT.TH1F("pmt_integral",'',100,0,150e+3)
     ret[('ambe','pmt_tot')]  = ROOT.TH1F("pmt_tot",'',100,0,400)
+    ret[('ambe','pmt_density')] = ROOT.TH1F("pmt_density",'',100,0,1000)
 
     ## 2D vars
     ret[('ambe','integralvslength')] =  ROOT.TH2F("integralvslength",'',100,0,300,100,0,15e3)
@@ -228,7 +237,7 @@ def fillSpectra(cluster='sc'):
     titles = {'integral': 'photons', 'integralExt': 'photons', 'calintegral': 'energy (keV)', 'calintegralExt': 'energy (keV)', 'caldensity': 'density (eV/pixel)',
               'length':'length (pixels)', 'width':'width (pixels)', 'nhits': 'active pixels', 'slimness': 'width/length', 'density': 'photons/pixel',
               'cmos_integral': 'CMOS integral (photons)', 'cmos_mean': 'CMOS mean (photons)', 'cmos_rms': 'CMOS RMS (photons)',
-              'pmt_integral': 'PMT integral (V)', 'pmt_tot': 'PMT T.O.T. (ns)',
+              'pmt_integral': 'PMT integral (mV)', 'pmt_tot': 'PMT T.O.T. (ns)', 'pmt_density': 'PMT density (mV/ns)',
               'tgausssigma': '#sigma_{transverse} (pixels)'}
 
     titles2d = {'integralvslength': ['length (pixels)','photons'], 'densityvslength' : ['length (pixels)','density (ph/pix)'],
@@ -265,6 +274,7 @@ def fillSpectra(cluster='sc'):
                 ret[runtype,cmosvar].Fill(getattr(event,cmosvar))
             for pmtvar in ['pmt_integral','pmt_tot']:
                 ret[runtype,pmtvar].Fill(getattr(event,pmtvar))
+            ret[runtype,'pmt_density'].Fill(getattr(event,'pmt_integral')/getattr(event,'pmt_tot'))
             for isc in range(getattr(event,"nSc" if cluster=='sc' else 'nCl')):
                 #if getattr(event,"{clutype}_iteration".format(clutype=cluster))[isc]!=2:
                 #    continue
@@ -282,9 +292,13 @@ def fillSpectra(cluster='sc'):
                 slimness = getattr(event,"{clutype}_width".format(clutype=cluster))[isc] / getattr(event,"{clutype}_length".format(clutype=cluster))[isc]
                 # gainCalibnInt = integral*1.1 if runtype=='ambe' else integral 
                 ## energy calibrated for saturation
-                calib = saturationFactor(max(0,density)) # ev/ph
+                calib = saturationFactorNLO(max(0,density)) # ev/ph
                 calibEnergy = integral * calib / 1000. # keV
                 calibDensity  = density * calib # eV/pix
+
+                if not withinFC(xmean,ymean):
+                    continue
+
                 ##########################
                 ## SOME DEBUGGING CUTS...
                 ##########################
@@ -301,15 +315,15 @@ def fillSpectra(cluster='sc'):
                 #if photons < 1000:
                 #    continue
                 # if not is60keVBkg(length,density):
-                #     continue
+                #      continue
                 #if not slimnessCut(getattr(event,"{clutype}_length".format(clutype=cluster))[isc],getattr(event,"{clutype}_width".format(clutype=cluster))[isc]):
                  #   continue
                 #if not integralCut(getattr(event,"{clutype}_integral".format(clutype=cluster))[isc]):
                 #    continue
+
                 ##########################
-                #if not withinFCFull(xmin,ymin,xmax,ymax):
-                if not withinFC(xmean,ymean):
-                    continue
+                ## the AmBe selection
+                ##########################
                 # remove long/slim cosmics
                 if length>500 or slimness<0.3:
                     continue
@@ -319,6 +333,8 @@ def fillSpectra(cluster='sc'):
                 # remove the 60 keV background in AmBe and
                 if is60keVBkg(length,density):
                     continue
+                ##########################
+
                 for var in ['integral','length','width','nhits','tgausssigma']:
                     ret[(runtype,var)].Fill(getattr(event,("{clutype}_{name}".format(clutype=cluster,name=var)))[isc])
                 ret[(runtype,'integralExt')].Fill(getattr(event,"{clutype}_integral".format(clutype=cluster))[isc])

--- a/snakes.py
+++ b/snakes.py
@@ -213,7 +213,7 @@ class SnakesFactory:
         ## SUPERCLUSTERING
         from supercluster import SuperClusterAlgorithm
         superclusterContours = []
-        scAlgo = SuperClusterAlgorithm(shape=rescale)
+        scAlgo = SuperClusterAlgorithm(shape=rescale,debugmode=self.options.debug_mode)
         u,indices = np.unique(db.labels_,return_index = True)
         allclusters_it1 = [X1[db.labels_ == i] for i in u[list(np.where(db.tag_[indices] == 1)[0])].tolist()]
         allclusters_it2 = [X1[db.labels_ == i] for i in u[list(np.where(db.tag_[indices] == 2)[0])].tolist()]

--- a/supercluster.py
+++ b/supercluster.py
@@ -6,14 +6,15 @@ from scipy.stats import pearsonr
 from energyCalibrator import EnergyCalibrator
 
 class SuperClusterAlgorithm:
-    def __init__(self,shape=512,neighbor_window=3):
+    def __init__(self,shape=512,neighbor_window=3,debugmode=False):
         self.shape = shape
         self.neighbor_window = neighbor_window
+        self.debug = debugmode
 
         # supercluster energy calibration for the saturation effect
         filePar = open('modules_config/energyCalibrator.txt','r')
         params = eval(filePar.read())
-        self.calibrator = EnergyCalibrator(params)
+        self.calibrator = EnergyCalibrator(params,self.debug)
         
     def clusters_neighborood(self,basic_clusters,raw_data):
         neighboroods = np.zeros([self.shape,self.shape],dtype=float)
@@ -100,7 +101,9 @@ class SuperClusterAlgorithm:
                 x = scpixels[:, 0]; y = scpixels[:, 1]
                 corr, p_value = pearsonr(x, y)
                 sclu.pearson = p_value
-                sclu.calibratedIntegral = self.calibrator.calibratedIntegral(sclu.hits_fr)
+                if self.debug:
+                    print ( "SUPERCLUSTER BARE INTEGRAL = {integral:.1f}".format(integral=sclu.integral()) )
+                sclu.calibratedEnergy = self.calibrator.calibratedEnergy(sclu.hits_fr)
                 sclu.pathlength = self.calibrator.clusterLength()
                 superClusters.append(sclu)
 

--- a/treeVars.py
+++ b/treeVars.py
@@ -40,7 +40,7 @@ class AutoFillTreeProducer:
         self.outTree.branch('{name}_integral'.format(name=name),     'F', lenVar=sizeStr)
         # filled only for the supercluster
         if name=='sc':
-            self.outTree.branch('{name}_calibintegral'.format(name=name), 'F', lenVar=sizeStr)
+            self.outTree.branch('{name}_energy'.format(name=name), 'F', lenVar=sizeStr)
             self.outTree.branch('{name}_pathlength'.format(name=name),    'F', lenVar=sizeStr)
         self.outTree.branch('{name}_length'.format(name=name),       'F', lenVar=sizeStr)
         self.outTree.branch('{name}_width'.format(name=name),        'F', lenVar=sizeStr)
@@ -87,7 +87,7 @@ class AutoFillTreeProducer:
         self.outTree.fillBranch('{name}_integral'.format(name=name), [cl.integral() for cl in clusters])
         # filled only for the supercluster
         if name=='sc':
-            self.outTree.fillBranch('{name}_calibintegral'.format(name=name), [cl.calibratedIntegral for cl in clusters])
+            self.outTree.fillBranch('{name}_energy'.format(name=name), [cl.calibratedEnergy for cl in clusters])
             self.outTree.fillBranch('{name}_pathlength'.format(name=name),    [cl.pathlength for cl in clusters])
         self.outTree.fillBranch('{name}_length'.format(name=name),   [cl.shapes['long_width'] for cl in clusters])
         self.outTree.fillBranch('{name}_width'.format(name=name),    [cl.shapes['lat_width'] for cl in clusters])

--- a/utilities.py
+++ b/utilities.py
@@ -59,3 +59,14 @@ class utils:
 
     def get_git_revision_hash(self):
         return subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+


### PR DESCRIPTION
Few changes, but might be fundamental:

1. use circles of radius = 5sigma to make the slices of the track to compute the calibrated integral
2. use the new master formula from D. Pinci to correct for saturation (see below). Note that the new method returns energy in keV, so I changed the name of the variable in the tree.

![image](https://user-images.githubusercontent.com/4517974/80242645-f5178680-8665-11ea-9f48-eb5c587e27c9.png)

On the analysis side, add the possibility to plot the corrected energy with the above formula (need a c++ function, so added functions.cc)