### PR TITLE
Save the energy profile along the path in the tree

### DIFF
--- a/energyCalibrator.py
+++ b/energyCalibrator.py
@@ -152,7 +152,7 @@ class EnergyCalibrator:
             print ("Slices densities = " + ', '.join('{:.1f}'.format(i) for i in densities))
             print ("Slices calib energy = " + ', '.join('{:.1f}'.format(i) for i in calibSlicesEnergy))
             print (bcolors.OKGREEN + "supercluster calibrated integral = {ene:.1f} keV".format(ene=calibEnergy) + bcolors.ENDC)
-        return calibEnergy
+        return calibEnergy,calibSlicesEnergy
     
     def getSlices(self,hits):
     

--- a/supercluster.py
+++ b/supercluster.py
@@ -101,9 +101,13 @@ class SuperClusterAlgorithm:
                 x = scpixels[:, 0]; y = scpixels[:, 1]
                 corr, p_value = pearsonr(x, y)
                 sclu.pearson = p_value
+                ## slicesCalEnergy is useful for the profile along the path
+                calEnergy,slicesCalEnergy = self.calibrator.calibratedEnergy(sclu.hits_fr)
                 if self.debug:
                     print ( "SUPERCLUSTER BARE INTEGRAL = {integral:.1f}".format(integral=sclu.integral()) )
-                sclu.calibratedEnergy = self.calibrator.calibratedEnergy(sclu.hits_fr)
+                sclu.calibratedEnergy = calEnergy
+                sclu.nslices = len(slicesCalEnergy)
+                sclu.energyprofile = slicesCalEnergy
                 sclu.pathlength = self.calibrator.clusterLength()
                 superClusters.append(sclu)
 

--- a/treeVars.py
+++ b/treeVars.py
@@ -40,8 +40,10 @@ class AutoFillTreeProducer:
         self.outTree.branch('{name}_integral'.format(name=name),     'F', lenVar=sizeStr)
         # filled only for the supercluster
         if name=='sc':
-            self.outTree.branch('{name}_energy'.format(name=name), 'F', lenVar=sizeStr)
+            self.outTree.branch('{name}_nslices'.format(name=name), 'F', lenVar=sizeStr)
+            self.outTree.branch('{name}_energy'.format(name=name),  'F', lenVar=sizeStr)
             self.outTree.branch('{name}_pathlength'.format(name=name),    'F', lenVar=sizeStr)
+            self.outTree.branch('{name}_energyprof'.format(name=name),    'F', lenVar=sizeStr+'*nSlices')
         self.outTree.branch('{name}_length'.format(name=name),       'F', lenVar=sizeStr)
         self.outTree.branch('{name}_width'.format(name=name),        'F', lenVar=sizeStr)
         self.outTree.branch('{name}_longrms'.format(name=name),      'F', lenVar=sizeStr)
@@ -87,8 +89,10 @@ class AutoFillTreeProducer:
         self.outTree.fillBranch('{name}_integral'.format(name=name), [cl.integral() for cl in clusters])
         # filled only for the supercluster
         if name=='sc':
+            self.outTree.fillBranch('{name}_nslices'.format(name=name), [cl.nslices for cl in clusters])
             self.outTree.fillBranch('{name}_energy'.format(name=name), [cl.calibratedEnergy for cl in clusters])
             self.outTree.fillBranch('{name}_pathlength'.format(name=name),    [cl.pathlength for cl in clusters])
+            self.outTree.fillBranch('{name}_energyprof'.format(name=name),    [cl.energyprofile[i] for cl in clusters for i in range(cl.nslices)])
         self.outTree.fillBranch('{name}_length'.format(name=name),   [cl.shapes['long_width'] for cl in clusters])
         self.outTree.fillBranch('{name}_width'.format(name=name),    [cl.shapes['lat_width'] for cl in clusters])
         self.outTree.fillBranch('{name}_longrms'.format(name=name),  [cl.shapes['longrms'] for cl in clusters])


### PR DESCRIPTION
* Reconstruction: as title says. This is saves as an unrolled 1D array of (n super-clusters * n slices) in the tree. To de-unroll it at analysis level, sc_nslices is saved into the tree
* plotting: add more variables + selections to the list